### PR TITLE
expose default_value stringifier

### DIFF
--- a/cmdline.h
+++ b/cmdline.h
@@ -117,6 +117,12 @@ std::string readable_typename()
   return demangle(typeid(T).name());
 }
 
+template <class T>
+std::string default_value(T def)
+{
+  return detail::lexical_cast<std::string>(def);
+}
+
 template <>
 inline std::string readable_typename<std::string>()
 {
@@ -754,7 +760,7 @@ private:
     std::string full_description(const std::string &desc){
       return
         desc+" ("+detail::readable_typename<T>()+
-        (need?"":" [="+detail::lexical_cast<std::string>(def)+"]")
+        (need?"":" [="+detail::default_value<T>(def)+"]")
         +")";
     }
 


### PR DESCRIPTION
Allows overriding `cmdline::detail::default_value` to provide own default value string such as **auto** or **none**, for certain type values, so more meaningful help is provided to the user with `--help`.

Actually this is very very little modification that allows for example our program, that calculates automatically options with `0.0` default double values, to show `[=auto]`, using:

``` c++
template <>
inline std::string cmdline::detail::default_value<double>(double def) {
  if (def == 0.0) return "auto";
  return detail::lexical_cast<std::string>(def);
}
```
