### PR TITLE
Get non-const reference for option value if needed

### DIFF
--- a/cmdline.h
+++ b/cmdline.h
@@ -360,6 +360,14 @@ public:
   }
 
   template <class T>
+  T &get(const std::string &name) {
+    if (options.count(name)==0) throw cmdline_error("there is no flag: --"+name);
+    option_with_value<T> *p=dynamic_cast<option_with_value<T>*>(options.find(name)->second);
+    if (p==NULL) throw cmdline_error("type mismatch flag '"+name+"'");
+    return p->get();
+  }
+
+  template <class T>
   const T &get(const std::string &name) const {
     if (options.count(name)==0) throw cmdline_error("there is no flag: --"+name);
     const option_with_value<T> *p=dynamic_cast<const option_with_value<T>*>(options.find(name)->second);
@@ -705,6 +713,10 @@ private:
       this->desc=full_description(desc);
     }
     ~option_with_value(){}
+
+    T &get() {
+      return actual;
+    }
 
     const T &get() const {
       return actual;


### PR DESCRIPTION
Now it is possible to get non-const (read-write) reference to underlying
options value storage variable. This is useful if you want to modify some option
in place and store it back to cmdline::parser.
### Reasoning

If I want map some variables, so the modifications are reflected and stored back into `cmdline::parser`, I am using references in my code, for example:

``` c++
  auto &n_pixels    = cl.get<size_t>("n-pixels");
  auto &n_detectors = cl.get<size_t>("n-detectors");
  auto &n_emissions = cl.get<size_t>("n-emissions");
  auto &radious     = cl.get<double>("radious");
  auto &s_pixel     = cl.get<double>("s-pixel");
  auto &w_detector  = cl.get<double>("w-detector");
  auto &h_detector  = cl.get<double>("h-detector");
```

Now any changes to these variables will be takes when doing serialization, see my **Serialization** pull request.
