### PR TITLE
Fix implicit conversion

### DIFF
--- a/cmdline.h
+++ b/cmdline.h
@@ -533,7 +533,7 @@ public:
   void parse_check(const std::vector<std::string> &args){
     if (!options.count("help"))
       add("help", '?', "print this message");
-    check(args.size(), parse(args));
+    check(static_cast<int>(args.size()), parse(args));
   }
 
   void parse_check(int argc, char *argv[]){


### PR DESCRIPTION
This fixes issue with never Clang with -Wall generating implicit conversion warnings.
