### PR TITLE
Undef macro `max`

### DIFF
--- a/cmdline.h
+++ b/cmdline.h
@@ -39,6 +39,10 @@
 #include <cxxabi.h>
 #include <cstdlib>
 
+#ifdef max
+#undef max
+#endif
+
 namespace cmdline{
 
 namespace detail{


### PR DESCRIPTION
This builtin macro conflicts with the function template `std::max()`